### PR TITLE
Add scikit-bio and related Caporaso Lab projects to list/timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,39 @@
-# A Plege to migrate to Python 3. 
+# A pledge to migrate to Python 3.
 
-This is the main website for a pledge to stop supporting Python 2 for free in open source software. 
+This is the main website for a pledge to stop supporting Python 2 for free in
+open source software.
 
-# run locally
+# Run locally
 
-Install Jekyll : `gem install jekyll`, `gem install gh-pages`
+Install Jekyll : `gem install jekyll`, `gem install github-pages`
 
 Clone this locally, `cd` in the newly created directory.
 
-run `jekyll serve -w` in one terminal, open you browse to `localhost:4000`.
+Run `jekyll serve -w` in one terminal, open your browser to `localhost:4000`.
 
-Modify the various files, refresh your browser and enjoy. 
+Modify the various files, refresh your browser and enjoy.
 
 PRs welcomed.
 
 # Add your project
 
-If you just want to add you project to the list of participating project, add a
-line in [the list of participating project](_sections/30-projects.md), it's
+If you just want to add your project to the list of participating projects, add
+a line in [the list of participating projects](_sections/30-projects.md). It's
 markdown so feel free to just list your project name or add a link, and make a
 pull request. You should even be able to [edit it
 online](https://github.com/python3statement/python3statement.github.io/edit/master/_sections/30-projects.md).
 
+## Add timeline information
 
-
-
-## Add timeline informations
-
-The front page also have a timeline chart, with past release dates, and future
-(planned) releases. You can also add you project there, if you have a specific
-date where you plan to drop Python 2 support. 
+The front page also has a timeline chart, with past release dates and future
+(planned) releases. You can also add your project there, if you have a specific
+date where you plan to drop Python 2 support.
 
 See [site.js](site.js) around [line
 100](https://github.com/python3statement/python3statement.github.io/blob/master/site.js#L103)
-to see how to add this kind of data. 
+to see how to add this kind of data.
 
+# Base template
 
-# Base template:
-
-This is a based on version of
-[github.com/t413/SinglePaged](https://github.com/t413/SinglePaged)
-
-
+This site is based on
+[github.com/t413/SinglePaged](https://github.com/t413/SinglePaged).

--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -9,6 +9,8 @@ style: center
 # Participating Projects
 
 - [IPython](https://ipython.org)
-- [Jupyter notebook](https://jupyter.org) 
-
-
+- [Jupyter notebook](https://jupyter.org)
+- [scikit-bio](http://scikit-bio.org)
+- [An Introduction to Applied Bioinformatics](http://readiab.org)
+- [QIIME](http://qiime.org)
+- [cual-id](https://github.com/johnchase/cual-id)

--- a/_sections/40-timeline.md
+++ b/_sections/40-timeline.md
@@ -15,4 +15,4 @@ extended support. (Python's own timeline is available
 
 <div id="visualization"></div>
 
-See how to [add  your project to the list of participating project](https://github.com/python3statement/python3statement.github.io#add-your-project) and to [this timeline](https://github.com/python3statement/python3statement.github.io#add-timeline-informations)
+See how to [add  your project to the list of participating projects](https://github.com/python3statement/python3statement.github.io#add-your-project) and to [this timeline](https://github.com/python3statement/python3statement.github.io#add-timeline-information)

--- a/_sections/50-why.md
+++ b/_sections/50-why.md
@@ -15,4 +15,4 @@ code to use Python 3:
 - [How to add Python 3 support to your code](https://docs.python.org/3/howto/pyporting.html)
 - [Stop supporting Python 2.6 for free](http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html) (Nick Coghlan)
 - [Why Python 4.0 won't be like Python 3.0](http://www.curiousefficiency.org/posts/2014/08/python-4000.html) (Nick Coghlan)
-- [SciKitBio Py3 Only RFC](https://github.com/biocore/scikit-bio-rfcs/blob/master/active/002-py3-only.md)
+- [scikit-bio py3-only RFC](https://github.com/biocore/scikit-bio-rfcs/blob/master/accepted/002-py3-only.md)

--- a/site.js
+++ b/site.js
@@ -119,6 +119,14 @@ $(document).ready(function (){
       {content: '7.x', start: '2018-01-01', end:'2019-06-12'},
       {content: '8.x', start: '2019-06-12', end:'2020-06-01'},
     ],
+    'scikit-bio':[
+      {content: '0.1.1 - 0.4.2', start: '2014-05-16', end: '2016-05-30', py2:true},
+      {content: '0.5.0+', start: '2016-05-31', end: '2021-12-16'},
+    ],
+    'QIIME':[
+      {content: '1.x', start: '2010-04-09', end: '2017-12-31', py2:true},
+      {content: '2.x+', start: '2016-07-11', end: '2021-12-16'},
+    ],
     // for tests, rando example
     //'matplotlib':[
     //  {content: 'matplotlib 2.x', start: '2015-06-01', end:'2018-06-01', py2:true},
@@ -129,7 +137,7 @@ $(document).ready(function (){
     //  {content: '0.19', start: '2016-11-02', end:'2017-12-01'},
     //]
 
-  
+
   }
 
   // Create a DataSet (allows two way data-binding)
@@ -159,7 +167,7 @@ $(document).ready(function (){
 
   var options = {
     clickToUse: true,
-    groupOrder: 'group'  
+    groupOrder: 'group'
   };
 
   // Create a Timeline
@@ -169,4 +177,3 @@ $(document).ready(function (){
   timeline.addCustomTime(Date.parse('2020-01-01'))
 
 });
-


### PR DESCRIPTION
Also copy-edited the readme and fixed a `gem install` command that didn't work for me.

On the timeline, I wasn't sure what end date to use for Python 3-only versions of scikit-bio and QIIME. We don't have a clear end date to stop supporting these projects, nor specific future release dates/versions past the ones included here. I used Python 3.6's end date since that was the latest end date on the timeline. Please let me know if you'd like it changed to something else.