### PR TITLE
Add Numpy timeline

### DIFF
--- a/site.js
+++ b/site.js
@@ -119,6 +119,11 @@ $(document).ready(function (){
       {content: '7.x', start: '2018-01-01', end:'2019-06-12'},
       {content: '8.x', start: '2019-06-12', end:'2020-06-01'},
     ],
+    'Numpy':[
+      {content: 'Py 2 & 3 full', start: '2010-08-31', end:'2018-12-31', py2:true},
+      {content: 'Py 2 bug fix', start: '2019-01-01', end:'2019-12-31', py2:true},
+      {content: 'Py 3 full', start: '2019-01-01', end:'2021-12-16'},
+    ],
     'Xonsh':[
       {content: '0.x series – Python 3.4+', start: '2015-03-09', end: '2021-12-16'},
     ],


### PR DESCRIPTION
Fixes #89.

Based on https://github.com/numpy/numpy/blob/master/doc/neps/nep-0014-dropping-python2.7-proposal.rst. 