### PR TITLE
Change ≥ to >= in Py2 code

### DIFF
--- a/_practicalities/intro.md
+++ b/_practicalities/intro.md
@@ -229,7 +229,7 @@ if sys.version_info < (3,):
 Unfortunately Frobulator 6.0 and above are not compatible with Python 2
 anymore, and you still ended up with this version installed on your system.
 That's a bummer; sorry about that. It should not have happened. Make sure you
-have pip ≥ 9.0 to avoid this kind of issues, as well as setuptools ≥ 24.2:
+have pip >= 9.0 to avoid this kind of issues, as well as setuptools >= 24.2:
 
  $ pip install pip setuptools --upgrade
 


### PR DESCRIPTION
Suggesting that due to locale differences, we probably should not include the symbol "≥" in the raw string to display to Python 2 users; have instead substituted >= in two places.  (And now I remember WHY we moved to Py3 only...)