### PR TITLE
Add python-chess to list (491 stars)

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -46,6 +46,7 @@ for some that aren't directly comparable. -->
 
 &nbsp; <!--break separating project with image from without -->
 
+- [python-chess](https://github.com/niklasf/python-chess)
 - [Altair](https://github.com/ellisonbg/altair)
 - [music21](http://web.mit.edu/music21/)
 - [imageio](https://imageio.github.io)


### PR DESCRIPTION
[python-chess](https://github.com/niklasf/python-chess) will very likely drop Python 2 support early 2019.