### PR TITLE
Add pandas timeline

### DIFF
--- a/site.js
+++ b/site.js
@@ -120,6 +120,10 @@ $(document).ready(function (){
       {content: '7.x', start: '2018-12-01', end:'2019-12-12'},
       {content: '8.x', start: '2019-12-12', end:'2020-12-01'},
     ],
+    'pandas':[
+      {content: 'Python 2 & 3', start: '2011-10-10', end:'2018-12-31', py2:true},
+      {content: 'Python 3 only', start: '2019-01-01', end:'2021-12-16'},
+    ],
     'Numpy':[
       {content: 'Py 2 & 3 full', start: '2010-08-31', end:'2018-12-31', py2:true},
       {content: 'Py 2 bug fix', start: '2019-01-01', end:'2019-12-31', py2:true},


### PR DESCRIPTION
> # Plan for dropping Python 2.7
>
> The Python core team plans to stop supporting Python 2.7 on January 1st, 2020. In line with [NumPy's plans](https://github.com/numpy/numpy/blob/master/doc/neps/nep-0014-dropping-python2.7-proposal.rst#plan-for-dropping-python-27-support), all pandas releases through December 31, 2018 will support Python 2.
>
> The final release before **December 31, 2018** will be the last release to support Python 2. The released package will continue to be available on PyPI and through conda.
>
> Starting **January 1, 2019**, all releases will be Python 3 only.

https://github.com/pandas-dev/pandas/blob/master/doc/source/install.rst#plan-for-dropping-python-27