### PR TITLE
Fix links to video and slides

### DIFF
--- a/_practicalities/intro.md
+++ b/_practicalities/intro.md
@@ -29,10 +29,9 @@ least the main points -- should ease lots of the pain.
 
 We gave a 
     [talk at PyCon 2017](https://www.youtube.com/watch?v=2DkfPzWWC2Q)
-    ([slides](https://carreau.github.io/pycon2017/#/))
-    , and at 
-    [pybay](https://www.youtube.com/watch?v=2DkfPzWWC2Q)
-    ([slides](https://carreau.github.io/pycon2017/#/)). 
+    ([slides](https://speakerdeck.com/pycon2017/py3-compatibility-in-a-user-friendly-manner), and at 
+    [PyBay](https://www.youtube.com/watch?v=3i6n1RwqQCo)
+    ([slides](https://speakerdeck.com/pybay/2017-building-bridges-stopping-python-2-without-damages)). 
 
 ## The problem
 


### PR DESCRIPTION
https://carreau.github.io/pycon2017/#/ redirects to https://matthiasbussonnier.com/pycon2017/#/ which is 404.

Instead Link to another place where they are hosted.

Also link to correct PyBay video and slides.