### PR TITLE
Remove references to "Scientific Python" from title and description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,9 +14,9 @@ markdown: kramdown
 
 
 ### content configuration ###
-title:       "Sunsetting Python 2 support in scientific Python projects"
+title:       "Sunsetting Python 2 support"
 keywords:    "Python 3, support, Jupyter, IPython, matplotlib, Python 2, Legacy Python"
-description: "Scientific Python projects will drop Python 2 support by 2020."
+description: "A pledge to drop Python 2 support by 2020."
 source_link: "https://github.com/python3statement/python3statement.github.io"
 favicon:     #put a path like: "img/favicon.ico"
 touch_icon:  #put a path like: "img/apple-touch-icon.png"


### PR DESCRIPTION
Further to #99: since 3 out of the first 8 projects listed on the page are unrelated to scientific Python, it no longer makes sense for this to be in the page title.