### PR TITLE
Fail early at import time: First choice is upgrade to Python 3

### DIFF
--- a/_practicalities/intro.md
+++ b/_practicalities/intro.md
@@ -225,25 +225,25 @@ if sys.version_info < (3,):
     raise ImportError(
     """You are running Frobulator 6.0 on Python 2
 
-Unfortunately Frobulator 6.0 and above are not compatible with Python 2
-anymore, and you still ended up with this version installed on your system.
-That's a bummer; sorry about that. It should not have happened. Make sure you
-have pip >= 9.0 to avoid this kind of issues, as well as setuptools >= 24.2:
+Frobulator 6.0 and above are no longer compatible with Python 2, and you still 
+ended up with this version installed. That's unfortunate; sorry about that. 
+It should not have happened. Make sure you have pip >= 9.0 to avoid this kind 
+of issue, as well as setuptools >= 24.2:
 
  $ pip install pip setuptools --upgrade
 
-You have various other choices
+Your choices:
 
-- install an older version of Frobulator:
+- Upgrade to Python 3.
+
+- Install an older version of Frobulator:
 
  $ pip install 'frobulator<6.0'
-
-- Upgrade your system to use Python 3.
 
 It would be great if you can figure out how this version ended up being
 installed, and try to check how to prevent that for future users.
 
-See the following url for more up-to-date information:
+See the following URL for more up-to-date information:
 
 https://i.am.an/url
 


### PR DESCRIPTION
It's better to upgrade to Python 3 than to use older versions.

Also, it's not unfortunate that Frobulator 6.0 is incompatible with Python 2, that is intentional. However, it is unfortunate to end up with F6 on P2.

Plus some minor rewording for brevity and readability.