### PR TITLE
Changing IPython dates for 6.x and 7.x

### DIFF
--- a/site.js
+++ b/site.js
@@ -116,8 +116,8 @@ $(document).ready(function (){
       {content: '3.x', start: '2015-02-27', end:'2015-08-10', py2:true},
       {content: '4.x', start: '2015-08-11', end:'2016-07-07', py2:true},
       {content: 'IPython 5.x LTS', start: '2016-07-08', end:'2019-06-01', py2:true},
-      {content: '6.x', start: '2017-04-19', end:'2018-12-01'},
-      {content: '7.x', start: '2018-12-01', end:'2019-12-12'},
+      {content: '6.x', start: '2017-04-19', end:'2018-09-27'},
+      {content: '7.x', start: '2018-09-27', end:'2019-12-12'},
       {content: '8.x', start: '2019-12-12', end:'2020-12-01'},
     ],
     'pandas':[


### PR DESCRIPTION
Updated release dates for 6.x end and beginning of 7.x