### PR TITLE
Hypothesis will drop Python2 in 2020

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -68,6 +68,7 @@ for some that aren't directly comparable. -->
 
 &nbsp; <!--break separating project with image from without -->
 
+- [Hypothesis](https://github.com/HypothesisWorks/hypothesis)
 - [better-exceptions](https://github.com/qix-/better-exceptions)
 - [python-chess](https://github.com/niklasf/python-chess)
 - [Altair](https://github.com/ellisonbg/altair)


### PR DESCRIPTION
Added above better-exceptions as Hypothesis currently has more stars and [seems set to stay that way](https://timqian.com/star-history/#qix-/better-exceptions&HypothesisWorks/hypothesis).

I'm a maintainer of Hypothesis, and the team has discussed and documented that we will be dropping Python 2 in January 2020 unless someone starts paying commercial support fees (which, fortunately or unfortunately, seems unlikely).