### PR TITLE
Add folium to participating projects

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -96,6 +96,7 @@ for some that aren't directly comparable. -->
 - [Pyramid](https://trypyramid.com)
 - [multiconf](https://github.com/lhupfeldt/multiconf)
 - [jenkinsflow](https://github.com/lhupfeldt/jenkinsflow)
+- [folium](https://github.com/python-visualization/folium)
 
 <!-- Adding a new project without a logo? They're roughly sorted by Github stars.
 Try to insert yours in order. We use judgment for projects not on Github, and

--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -74,6 +74,7 @@ for some that aren't directly comparable. -->
 
 &nbsp; <!--break separating project with image from without -->
 
+- [folium](https://github.com/python-visualization/folium)
 - [better-exceptions](https://github.com/qix-/better-exceptions)
 - [umap-learn](https://github.com/lmcinnes/umap)
 - [hdbscan](https://github.com/scikit-learn-contrib/hdbscan)
@@ -96,7 +97,6 @@ for some that aren't directly comparable. -->
 - [Pyramid](https://trypyramid.com)
 - [multiconf](https://github.com/lhupfeldt/multiconf)
 - [jenkinsflow](https://github.com/lhupfeldt/jenkinsflow)
-- [folium](https://github.com/python-visualization/folium)
 
 <!-- Adding a new project without a logo? They're roughly sorted by Github stars.
 Try to insert yours in order. We use judgment for projects not on Github, and


### PR DESCRIPTION
The next release of folium will be the last to support Python 2. See https://github.com/python-visualization/folium/pull/1087.