### PR TITLE
Add NetworkX

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -75,6 +75,7 @@ for some that aren't directly comparable. -->
 
 &nbsp; <!--break separating project with image from without -->
 
+- [NetworkX](https://github.com/networkx/networkx)
 - [folium](https://github.com/python-visualization/folium)
 - [better-exceptions](https://github.com/qix-/better-exceptions)
 - [umap-learn](https://github.com/lmcinnes/umap)


### PR DESCRIPTION
The release candidate for 2.3 is out:
https://pypi.org/project/networkx/2.3rc1/
It is Python 3 only.  I will release 2.3 final in a week or so.