### PR TITLE
Add param to only squash single image

### DIFF
--- a/scripts/squash-images.sh
+++ b/scripts/squash-images.sh
@@ -4,7 +4,7 @@ set -e
 # pip install pillow
 if [ ! -z $1 ]
 then
-    python3 scripts/thumbnail-images.py --inspec $1
+    python3 scripts/thumbnail-images.py --file $1
 else
     python3 scripts/thumbnail-images.py
 fi

--- a/scripts/squash-images.sh
+++ b/scripts/squash-images.sh
@@ -2,7 +2,12 @@
 set -e
 
 # pip install pillow
-python3 scripts/thumbnail-images.py
+if [ ! -z $1 ]
+then
+    python3 scripts/thumbnail-images.py --inspec $1
+else
+    python3 scripts/thumbnail-images.py
+fi
 
 # https://pmt.sourceforge.io/pngcrush/
 # On Mac: brew install pngcrush
@@ -11,4 +16,9 @@ python3 scripts/thumbnail-images.py
 #   -ow     Overwrite
 #   -brute  Use brute-force: try 176 different methods
 
-find . -iname '*.png' -exec pngcrush -ow -brute {} \;
+if [ ! -z $1 ]
+then
+    pngcrush -ow -brute $1
+else
+    find . -iname '*.png' -exec pngcrush -ow -brute {} \;
+fi

--- a/scripts/thumbnail-images.py
+++ b/scripts/thumbnail-images.py
@@ -14,10 +14,10 @@ parser = argparse.ArgumentParser(
     description="Thumbnail images to a maximum size",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
-parser.add_argument("--inspec", default="assets/*.png", help="Input file specification")
+parser.add_argument("--file", default="assets/*.png", help="Input file specification")
 args = parser.parse_args()
 
-for infile in glob.glob("assets/*.png"):
+for infile in glob.glob(args.file):
     im = Image.open(infile)
     if im.width <= max_size[0] and im.height <= max_size[1]:
         continue

--- a/scripts/thumbnail-images.py
+++ b/scripts/thumbnail-images.py
@@ -3,11 +3,19 @@
 """
 Thumbnail images to a maximum of 320px wide and 160px high
 """
+import argparse
 import glob
 
 from PIL import Image  # pip install pillow
 
 max_size = 320, 160
+
+parser = argparse.ArgumentParser(
+    description="Thumbnail images to a maximum size",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("--inspec", default="assets/*.png", help="Input file specification")
+args = parser.parse_args()
 
 for infile in glob.glob("assets/*.png"):
     im = Image.open(infile)


### PR DESCRIPTION
Fixes #207.

`scripts/squash-images.sh assets/newlogo.png` will squash only that image.

`scripts/squash-images.sh` will do all of them.
