### PR TITLE
Add PyQt5 to projects

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -86,6 +86,7 @@ for some that aren't directly comparable. -->
 
 - [NetworkX](https://github.com/networkx/networkx)
 - [folium](https://github.com/python-visualization/folium)
+- [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5)
 - [better-exceptions](https://github.com/qix-/better-exceptions)
 - [umap-learn](https://github.com/lmcinnes/umap)
 - [hdbscan](https://github.com/scikit-learn-contrib/hdbscan)


### PR DESCRIPTION
I'm adding PyQt5 with [permission](https://www.riverbankcomputing.com/pipermail/pyqt/2019-May/041787.html) of the author (Phil Thompson of Riverbank Computing).

PyQt5 isn't on Github, so I used pypistats for a guesstimate where to place it:

# pypistats

## networkx

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|  179,714 |  2,995,184 |   950,732 |

## folium

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|    7,858 |    184,798 |    56,105 |


## pyqt5

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|    4,905 |    187,976 |    55,151 |


## better-exceptions

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|       56 |      6,347 |     1,451 |

## umap-learn

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|    3,602 |     24,567 |    13,271 |

## hdbscan

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|      840 |     26,804 |     9,704 |
