### PR TITLE
Be friendlier with SVG logos,

### DIFF
--- a/combo.css
+++ b/combo.css
@@ -68,6 +68,7 @@ div.vis-item.vis-selected {
     margin: 10px;
     padding: 20px;
     font-size: 19px;
+    min-width: 105px;
 }
 
 


### PR DESCRIPTION
E.g: dask; dont have them "sqashed" by the surrounding .li. This seem to
mostly affect small width and svg logo like Dask; leaving the other ones
happy to be wider if necessary.