### PR TITLE
Add h5py to projects list

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -115,6 +115,7 @@ for some that aren't directly comparable. -->
 - [better-exceptions](https://github.com/qix-/better-exceptions) <!-- url:https://github.com/qix-/better-exceptions sg:3363 -->
 - [umap-learn](https://github.com/lmcinnes/umap) <!-- url:https://github.com/lmcinnes/umap sg:2925 -->
 - [hdbscan](https://github.com/scikit-learn-contrib/hdbscan) <!-- url:https://github.com/scikit-learn-contrib/hdbscan sg:1300 -->
+- [h5py](https://github.com/h5py/h5py/) <!-- url:https://github.com/h5py/h5py/ sg:1181 -->
 - [python-chess](https://github.com/niklasf/python-chess) <!-- url:https://github.com/niklasf/python-chess sg:791 -->
 - [Altair](https://github.com/ellisonbg/altair) <!-- url:https://github.com/ellisonbg/altair sg:236 -->
 - [music21](http://web.mit.edu/music21/)


### PR DESCRIPTION
Discussed at https://github.com/h5py/h5py/issues/1207

h5py has no logo that I'm aware of.