### PR TITLE
add awslimitchecker to list of projects

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -120,6 +120,7 @@ for some that aren't directly comparable. -->
 - [hdbscan](https://github.com/scikit-learn-contrib/hdbscan) <!-- url:https://github.com/scikit-learn-contrib/hdbscan sg:1300 -->
 - [h5py](https://github.com/h5py/h5py/) <!-- url:https://github.com/h5py/h5py/ sg:1181 -->
 - [python-chess](https://github.com/niklasf/python-chess) <!-- url:https://github.com/niklasf/python-chess sg:791 -->
+- [awslimitchecker](https://github.com/jantman/awslimitchecker) <!-- url:https://github.com/jantman/awslimitchecker sg:308 -->
 - [Altair](https://github.com/ellisonbg/altair) <!-- url:https://github.com/ellisonbg/altair sg:236 -->
 - [music21](http://web.mit.edu/music21/)
 - [imageio](https://imageio.github.io)


### PR DESCRIPTION
Per https://github.com/jantman/awslimitchecker/issues/438 the announcement of 2.7 end-of-support will be present in this week's release, along with a PendingDeprecationWarning, and support for all Python versions < 3.5 will be ended on January 1, 2020.

If you're adding a project to the Python 3 statement, please ensure you have:

- [x] Discussed dropping Python 2 support with all maintainers
- [x] Discussed signing the statement with all maintainers
- [ ] Added a suitable logo if the project has one
  - [ ] Approximately square logos generally fit better than banners
  - [ ] Compressed the logo to save bandwidth (run `scripts/squash-images.sh` on it)
- [x] Checked the Netlify preview made from the pull request
