### PR TITLE
ENH: Add statsmodels

### DIFF
--- a/_sections/30-projects.md
+++ b/_sections/30-projects.md
@@ -39,6 +39,7 @@ These projects pledge to drop Python 2 support in or before 2020.
 - [![](assets/spyder.png)Spyder](https://www.spyder-ide.org) <!-- url:https://github.com/spyder-ide/spyder sg:4497 -->
 - [![](assets/pytest1.png)pytest](https://docs.pytest.org/en/latest) <!-- url:https://github.com/pytest-dev/pytest sg:4328 -->
 - [![](assets/tensorpack.png)Tensorpack](https://github.com/tensorpack/tensorpack) <!-- url:https://github.com/tensorpack/tensorpack sg:4289 -->
+- [![](assets/statsmodels.svg)statsmodels](https://www.statsmodels.org/stable) <!-- url:https://github.com/statsmodels/statsmodels sg:5079 -->
 - [![](assets/pymc3.png)PyMC3](https://github.com/pymc-devs/pymc3) <!-- url:https://github.com/pymc-devs/pymc3 sg:4268 -->
 - [![](https://cython.org/logo/cython-logo-C.svg)Cython](https://cython.org/) <!-- url:https://github.com/cython/cython sg:4162 -->
 - [![](assets/marshmallow.png)marshmallow](https://github.com/marshmallow-code/marshmallow) <!-- url:https://github.com/marshmallow-code/marshmallow sg:3686 -->

--- a/assets/statsmodels.svg
+++ b/assets/statsmodels.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1024.8022"
+   height="1024.0273"
+   viewBox="0 0 271.14559 270.94057"
+   version="1.1"
+   id="svg3100"
+   sodipodi:docname="statsmodels.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview3728"
+     showgrid="false"
+     inkscape:zoom="0.65520625"
+     inkscape:cx="775.80502"
+     inkscape:cy="399.39995"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3100" />
+  <defs
+     id="defs3094">
+    <clipPath
+       id="clipPath1464"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         rx="0"
+         ry="0.14095114"
+         y="26.203016"
+         x="0.0029871927"
+         height="270.94055"
+         width="271.1456"
+         id="rect1466"
+         style="fill:#444444;fill-opacity:0.13333333;stroke:none;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.22613065" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata3097">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     clip-path="url(#clipPath1464)"
+     id="layer1"
+     transform="translate(-0.00298719,-26.203016)">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#444444;stroke-width:30;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.389637,436.95325 c 0,0 -9.933742,-239.7295 48.46627,-273.92653 64.280963,-37.64071 115.006233,22.97054 154.506923,-10.25393 51.76708,-43.54185 44.27756,-197.596591 44.27756,-197.596591"
+       id="path3655"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 77.393751,291.61461 c -13.78268,0 -25.00018,-11.21715 -25.00018,-24.99982 0,-13.78303 11.2175,-25.00018 25.00018,-25.00018 13.782667,0 24.999819,11.21715 24.999819,25.00018 0,13.78267 -11.217152,24.99982 -24.999819,24.99982 z m 0,-34.21207 c -5.08361,0 16.04472,19.22937 -9.21225,9.21225 -4.72553,-1.87418 4.12864,9.21217 9.21225,9.21217 5.083621,0 9.212171,-4.12855 9.212171,-9.21217 0,-5.08361 -4.12855,-9.21225 -9.212171,-9.21225 z"
+       id="path3727"
+       style="fill:#3f51b5;fill-opacity:1;stroke:#3f51b5;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 187.62339,89.475577 c -13.78268,0 -25.00018,-11.21716 -25.00018,-24.999833 0,-13.78303 11.2175,-25.00018 25.00018,-25.00018 13.78267,0 24.99982,11.21715 24.99982,25.00018 0,13.782673 -11.21715,24.999833 -24.99982,24.999833 z m 0,-34.212083 c -5.08361,0 14.97564,19.095734 -9.21225,9.21225 -4.70592,-1.922898 4.12864,9.212173 9.21225,9.212173 5.08362,0 9.21217,-4.128553 9.21217,-9.212173 0,-5.08361 -4.12855,-9.21225 -9.21217,-9.21225 z"
+       id="path3727-4"
+       style="fill:#3f51b5;fill-opacity:1;stroke:#3f51b5;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 32.190044,127.2274 c -13.78268,0 -25.0001807,-11.21716 -25.0001807,-24.99983 0,-13.783036 11.2175007,-25.000186 25.0001807,-25.000186 13.78267,0 24.99982,11.21715 24.99982,25.000186 0,13.78267 -11.21715,24.99983 -24.99982,24.99983 z m 0,-34.212086 c -5.08361,0 14.842008,18.160296 -9.21225,9.212256 -4.764634,-1.77241 4.12864,9.21217 9.21225,9.21217 5.08362,0 9.21217,-4.12855 9.21217,-9.21217 0,-5.083616 -4.12855,-9.212256 -9.21217,-9.212256 z"
+       id="path3727-4-9"
+       style="fill:#3f51b5;fill-opacity:1;stroke:#3f51b5;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 236.80098,246.09552 c -13.78268,0 -25.00018,-11.21717 -25.00018,-24.99984 0,-13.78303 11.2175,-25.00018 25.00018,-25.00018 13.78267,0 24.99982,11.21715 24.99982,25.00018 0,13.78267 -11.21715,24.99984 -24.99982,24.99984 z m 0,-34.21209 c -5.08361,0 14.84201,18.76165 -9.21225,9.21225 -4.7249,-1.87576 4.12864,9.21217 9.21225,9.21217 5.08362,0 9.21217,-4.12855 9.21217,-9.21217 0,-5.08361 -4.12855,-9.21225 -9.21217,-9.21225 z"
+       id="path3727-4-9-8"
+       style="fill:#3f51b5;fill-opacity:1;stroke:#3f51b5;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 129.35862,234.33566 c -13.78268,0 -25.00018,-11.21717 -25.00018,-24.99984 0,-13.78303 11.2175,-25.00018 25.00018,-25.00018 13.78267,0 24.99983,11.21715 24.99983,25.00018 0,13.78267 -11.21716,24.99984 -24.99983,24.99984 z m 0,-34.21209 c -5.08361,0 16.84653,17.49212 -9.21225,9.21225 -4.84493,-1.53942 4.12864,9.21217 9.21225,9.21217 5.08362,0 9.21217,-4.12855 9.21217,-9.21217 0,-5.08361 -4.12855,-9.21225 -9.21217,-9.21225 z"
+       id="path3727-4-9-8-1"
+       style="fill:#3f51b5;fill-opacity:1;stroke:#3f51b5;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 99.42444,85.199254 c -13.78268,0 -25.000177,-11.21716 -25.000177,-24.999823 0,-13.78303 11.217497,-25.00018 25.000177,-25.00018 13.78267,0 24.99982,11.21715 24.99982,25.00018 0,13.782663 -11.21715,24.999823 -24.99982,24.999823 z m 0,-34.212073 c -2.236067,1.982467 13.13864,19.689384 -9.21225,9.21225 -4.602997,-2.157687 4.12864,9.21217 9.21225,9.21217 5.08362,0 9.21217,-4.12855 9.21217,-9.21217 0,-5.08361 -5.40828,-12.584728 -9.21217,-9.21225 z"
+       id="path3727-4-8"
+       style="fill:#3f51b5;fill-opacity:1;stroke:#3f51b5;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
Add statsmodels which is already Python 3 only

If you're adding a project to the Python 3 statement, please ensure you have:

- [X] Discussed dropping Python 2 support with all maintainers
- [X] Discussed signing the statement with all maintainers
- [X] Added a suitable logo if the project has one
  - [X] Approximately square logos generally fit better than banners
  - [X] Compressed the logo to save bandwidth (run `scripts/squash-images.sh` on it)
- [x] Checked the Netlify preview made from the pull request
